### PR TITLE
Handle zero digits

### DIFF
--- a/g2pk/numerals.py
+++ b/g2pk/numerals.py
@@ -38,7 +38,8 @@ def process_num(num, sino=True):
     digit2dec = {d: dec for d, dec in zip(digits, decimals.split())}
 
     spelledout = []
-    for i, digit in enumerate(num[::-1]):
+    for i, digit in enumerate(num):
+        i = len(num) - i - 1
         if sino:
             if i == 0:
                 name = digit2name.get(digit, "")
@@ -47,9 +48,18 @@ def process_num(num, sino=True):
                 name = name.replace("일십", "십")
         else:
             if i == 0:
-                name = digit2mod[digit]
+                name = digit2mod.get(digit, "")
             elif i == 1:
-                name = digit2dec[digit]
+                name = digit2dec.get(digit, "")
+        if digit == '0':
+            if i % 4 == 0:
+                last_three = spelledout[-min(3, len(spelledout)):]
+                if "".join(last_three) == "":
+                    spelledout.append("")
+                    continue
+            else:
+                spelledout.append("")
+                continue
         if i == 2:
             name = digit2name.get(digit, "") + "백"
             name = name.replace("일백", "백")
@@ -70,8 +80,6 @@ def process_num(num, sino=True):
             name = name.replace("일천", "천")
         elif i == 8:
             name = digit2name.get(digit, "") + "억"
-        elif i == 8:
-            name = digit2name.get(digit, "") + "억"
         elif i == 9:
             name = digit2name.get(digit, "") + "십"
         elif i == 10:
@@ -88,7 +96,7 @@ def process_num(num, sino=True):
             name = digit2name.get(digit, "") + "천"
         spelledout.append(name)
 
-    return "".join(elem for elem in spelledout[::-1])
+    return "".join(elem for elem in spelledout)
 
 
 def convert_num(string):


### PR DESCRIPTION
다음과 같이 숫자 중간에 `0`이 포함된 경우, 올바르지 못하게 처리하는 이슈를 수정합니다.

기존 코드
```python3
print(process_num("123,406,709", sino=True))  # 일억이천삼백사십만육천칠백십구 (잘못됨)
print(process_num("123,406,709", sino=False))  # 오류!
print(process_num("100,006,709", sino=True))  # 일억천백십만육천칠백십구 (잘못됨)
print(process_num("100,006,709", sino=False))  # 오류!
print(process_num("2014", sino=True))  # 이천백십사 (잘못됨)
print(process_num("2014", sino=False))  # 이천백열네 (잘못됨)
print(process_num("123,456,789", sino=True))  # 일억이천삼백사십오만육천칠백팔십구
print(process_num("123,456,789", sino=False))  # 일억이천삼백사십오만육천칠백여든아홉
print(convert_num("우리 3시/B 10분/B에 만나자."))  # 우리 세시/B 십분/B에 만나자.
```

수정 코드
```python3
print(process_num("123,406,709", sino=True))  # 일억이천삼백사십만육천칠백구
print(process_num("123,406,709", sino=False))  # 일억이천삼백사십만육천칠백아홉
print(process_num("100,006,709", sino=True))  # 일억육천칠백구
print(process_num("100,006,709", sino=False))  # 일억육천칠백아홉
print(process_num("2014", sino=True))  # 이천십사
print(process_num("2014", sino=False))  # 이천열네
print(process_num("123,456,789", sino=True))  # 일억이천삼백사십오만육천칠백팔십구
print(process_num("123,456,789", sino=False))  # 일억이천삼백사십오만육천칠백여든아홉
print(convert_num("우리 3시/B 10분/B에 만나자."))  # 우리 세시/B 십분/B에 만나자.
```