### PR TITLE
Replace KoNLPy MeCab with python-mecab-ko

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ That's one of the reasons your contributions are more than welcome.
 ## Requirements
 * python >= 3.6
 * jamo
-* Mecab (Consult http://konlpy.org/en/latest/install/ for installation)
+* [python-mecab-ko](https://github.com/jonghwanhyeon/python-mecab-ko)
 * konlpy
 * nltk
 

--- a/g2pk/g2pk.py
+++ b/g2pk/g2pk.py
@@ -6,8 +6,8 @@ https://github.com/kyubyong/g2pK
 import os, re
 
 import nltk
+import mecab
 from jamo import h2j
-from konlpy.tag import Mecab
 from nltk.corpus import cmudict
 
 # For further info. about cmu dict, consult http://www.speech.cs.cmu.edu/cgi-bin/cmudict.
@@ -24,8 +24,8 @@ from g2pk.numerals import convert_num
 
 
 class G2p(object):
-    def __init__(self, dict_path=''):
-        self.mecab = self.get_mecab(dict_path)
+    def __init__(self):
+        self.mecab = self.get_mecab()
         self.table = parse_table()
 
         self.cmu = cmudict.dict() # for English
@@ -33,15 +33,12 @@ class G2p(object):
         self.rule2text = get_rule_id2text() # for comments of main rules
         self.idioms_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "idioms.txt")
 
-    def get_mecab(self, dict_path):
+    def get_mecab(self):
         try:
-            if dict_path:
-                return Mecab(dict_path) # for annotation
-            else:
-                return Mecab()
+            return mecab.MeCab()
         except Exception as e:
             raise Exception(
-                'If you want to install mecab, The command is.. bash <(curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh)'
+                'If you want to install mecab, The command is... pip install python-mecab-ko'
             )
 
     def idioms(self, string, descriptive=False, verbose=False):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ REQUIRED_PACKAGES = [
     'jamo',
     'nltk',
     'konlpy',
-    'mecab'
+    'python-mecab-ko',
 ]
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ REQUIRED_PACKAGES = [
 
 setuptools.setup(
     name="g2pK",
-    version="0.9.2",
+    version="0.9.3",
     author="Kyubyong Park",
     author_email="kbpark.linguist@gmail.com",
     description="g2pK: g2p module for Korean",


### PR DESCRIPTION
KoNLPy bash를 통해 MeCab을 설치하는 로직을 `python-mecab-ko`를 설치하는 로직으로 변경하였습니다.
변경 후, 재설치를 통해 정상 작동하는 것을 다음과 같이 확인하였습니다.

```pyhon
>>> from g2pk import G2p
>>> g2p = G2p()
>>> g2p("그 사람 조금 old 스쿨 같지 않아?")
'그 사람 조그 몰드 스쿨 갇찌 아나?'
>>> g2p("어제는 맑았는데, 오늘은 흐리다.")
'어제는 말간는데, 오느른 흐리다.'
```