### PR TITLE
Remove unnecessary dependency on KoNLPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ That's one of the reasons your contributions are more than welcome.
 * python >= 3.6
 * jamo
 * [python-mecab-ko](https://github.com/jonghwanhyeon/python-mecab-ko)
-* konlpy
 * nltk
 
 ## Installation

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,12 @@ with open("README.md", mode="r", encoding="utf-8") as fh:
 REQUIRED_PACKAGES = [
     'jamo',
     'nltk',
-    'konlpy',
     'python-mecab-ko',
 ]
 
 setuptools.setup(
     name="g2pK",
-    version="0.9.3",
+    version="0.9.5",
     author="Kyubyong Park",
     author_email="kbpark.linguist@gmail.com",
     description="g2pK: g2p module for Korean",


### PR DESCRIPTION
Pull request #5 was enough for completely eliminating konlpy dependency.

(I just found out that on PyPI the release version is 0.9.4 so this PR is assuming that next release would be 0.9.5.)